### PR TITLE
Add support for nonuniform timegrid

### DIFF
--- a/examples/car_control_complementarity/car_control_complementarity.py
+++ b/examples/car_control_complementarity/car_control_complementarity.py
@@ -83,6 +83,8 @@ def solve_ocp(opts=None):
     model, ocp = car_model()
     opts.terminal_time = 30
 
+    opts.h_ctrl_intervals = [0.5] * 10 + [2.0] * 10 + [0.5] * 10
+
     solver = nosnoc.NosnocSolver(opts, model, ocp)
 
     results = solver.solve()

--- a/nosnoc/nosnoc_opts.py
+++ b/nosnoc/nosnoc_opts.py
@@ -70,6 +70,7 @@ class NosnocOpts:
     # OCP only
     N_stages: int = 1
     equidistant_control_grid: bool = True  # NOTE: tested in test_ocp
+    h_ctrl_intervals: Optional[list] = None  # Manual time grid, list of length N_stages
 
     # generic path constraint handling
     g_path_at_fe: bool = False  # g_path evaluated at every finite element
@@ -186,6 +187,11 @@ class NosnocOpts:
             Warning(
                 "UNSUPPORTED option combination: StepEquilibrationMode.DIRECT* and constraint_handling != ConstraintHandling.LEAST_SQUARES"
             )
+        if self.h_ctrl_intervals is not None:
+            if len(self.h_ctrl_intervals) != self.N_stages:
+                raise ValueError(f"h_ctrl_intervals length must be equal to N_stages ({self.N_stages}), got {len(self.h_ctrl_intervals)}")
+            if abs(sum(self.h_ctrl_intervals) - self.terminal_time) > 1e-8:
+                raise ValueError(f"Sum of h_ctrl_intervals ({sum(self.h_ctrl_intervals)}) must equal terminal_time ({self.terminal_time})")
         return
 
     ## Options in matlab..

--- a/nosnoc/problem.py
+++ b/nosnoc/problem.py
@@ -271,7 +271,10 @@ class FiniteElement(FiniteElementBase):
         self.ind_bool = []
 
         # create variables
-        h_ctrl_stage = opts.terminal_time / opts.N_stages
+        if opts.h_ctrl_intervals is None:
+            h_ctrl_stage = opts.terminal_time / opts.N_stages
+        else:
+            h_ctrl_stage = opts.h_ctrl_intervals[ctrl_idx]
         h0 = np.array([h_ctrl_stage / np.array(opts.Nfe_list[ctrl_idx])])
         if opts.use_fesd:
             self.h = ca.SX.sym(f'h_{ctrl_idx}_{fe_idx}')
@@ -571,7 +574,10 @@ class FiniteElement(FiniteElementBase):
 
         # only step equilibration mode that does not require previous finite element
         if opts.step_equilibration == StepEquilibrationMode.HEURISTIC_MEAN:
-            h_fe = opts.terminal_time / (opts.N_stages * opts.Nfe_list[self.ctrl_idx])
+            if opts.h_ctrl_intervals is None:
+                h_fe = opts.terminal_time / (opts.N_stages * opts.Nfe_list[self.ctrl_idx])
+            else:
+                h_fe = opts.h_ctrl_intervals[self.ctrl_idx] / opts.Nfe_list[self.ctrl_idx]
             self.cost += opts.rho_h * (self.h - h_fe)**2
             return
         elif not self.fe_idx > 0:
@@ -797,8 +803,10 @@ class NosnocProblem(NosnocFormulationObject):
                 self.cost += fe.cost
                 self.add_fe_constraints(fe, ctrl_idx)
 
-            if opts.use_fesd and opts.equidistant_control_grid:
+            if opts.use_fesd and opts.equidistant_control_grid and opts.h_ctrl_intervals is None:
                 self.add_constraint(sum([fe.h for fe in stage]) - h_ctrl_stage)
+            elif opts.use_fesd and opts.h_ctrl_intervals is not None:
+                self.add_constraint(sum([fe.h for fe in stage]) - opts.h_ctrl_intervals[ctrl_idx])
 
             if opts.time_freezing and opts.equidistant_control_grid:
                 # TODO: make t0 dynamic (since now it needs to be 0!)


### PR DESCRIPTION
This PR adds support for nonuniform time grids by creating a list with user-specified time intervals using `opts.h_ctrl_intervals`, allowing users to specify custom time intervals for each control stage instead of using equidistant time intervals.